### PR TITLE
Issue :  Ease adding command process #3 

### DIFF
--- a/AutoScanWorker.py
+++ b/AutoScanWorker.py
@@ -166,6 +166,11 @@ def startAutoScan(calendarName, workerName):
     autoScanv2(calendarName, workerName)
     return
 
+@app.task
+def editToolConfig(command_name, remote_bin, plugin):
+    tools_to_register = Utils.loadToolsConfig()
+    tools_to_register[command_name] = {"bin":remote_bin, "plugin":plugin}
+    Utils.saveToolsConfig(tools_to_register)
 
 def autoScanv2(databaseName, workerName):
     """

--- a/core/Application/Dialogs/ChildDialogEditCommandSettings.py
+++ b/core/Application/Dialogs/ChildDialogEditCommandSettings.py
@@ -1,0 +1,66 @@
+"""Defines a dialog window for filling a tool settings"""
+
+import tkinter as tk
+import tkinter.ttk as ttk
+from core.Forms.FormPanel import FormPanel
+from core.Components.Utils import listPlugin
+from core.Views.ViewElement import ViewElement
+
+class ChildDialogEditCommandSettings:
+    """
+    Open a child dialog of a tkinter application to fill settings for a command
+    """
+
+    def __init__(self, parent, displayMsg="Choose a database to open:", default=None):
+        """
+        Open a child dialog of a tkinter application to ask a combobox option.
+
+        Args:
+            parent: the tkinter parent view to use for this window construction.
+            options: A list of string correspondig to options of the combobox
+            displayMsg: The message that will explain to the user what he is choosing.
+            default: Choose a default selected option (one of the string in options). default is None
+        """
+        self.app = tk.Toplevel(parent)
+        self.app.title("Upload result file")
+        self.rvalue = None
+        self.parent = parent
+        appFrame = ttk.Frame(self.app)
+        self.form = FormPanel()
+        self.form.addFormLabel(displayMsg, side=tk.TOP)
+        optionsFrame = self.form.addFormPanel(grid=True)
+        optionsFrame.addFormLabel("Remote bin path", row=0, column=0)
+        optionsFrame.addFormStr("bin", r".+", row=0, column=1)
+        optionsFrame.addFormLabel("Plugin", row=1, column=0)
+        optionsFrame.addFormCombo("plugin", tuple(listPlugin()), row=1, column=1)
+        self.form.addFormButton("Cancel", self.onError)
+        self.form.addFormButton("OK", self.onOk)
+        self.form.constructView(appFrame)
+        appFrame.pack(ipadx=10, ipady=10)
+        self.app.transient(parent)
+        try:
+            self.app.grab_set()
+        except tk.TclError:
+            pass
+
+    def onOk(self, _event):
+        """
+        Called when the user clicked the validation button. Set the rvalue attributes to the value selected and close the window.
+        """
+        # send the data to the parent
+        res, msg = self.form.checkForm()
+        if not res:
+            tk.messagebox.showwarning(
+                "Form not validated", msg, parent=self.app)
+            return
+        form_values = self.form.getValue()
+        form_values_as_dicts = ViewElement.list_tuple_to_dict(form_values)
+        self.rvalue = (form_values_as_dicts["bin"], form_values_as_dicts["plugin"])
+        self.app.destroy()
+
+    def onError(self, _event=None):
+        """
+        Close the dialog and set rvalue to None
+        """
+        self.rvalue = None
+        self.app.destroy()

--- a/core/Components/Utils.py
+++ b/core/Components/Utils.py
@@ -292,7 +292,7 @@ def saveToolsConfig(dic):
     """
     tool_config_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../config/tools.d/")
     default_tools_config = os.path.join(tool_config_folder, "tools.json")
-    with open(default_tools_config) as f:
+    with open(default_tools_config, "w") as f:
         f.write(json.dumps(dic))
 
 def loadClientConfig():

--- a/core/Components/Utils.py
+++ b/core/Components/Utils.py
@@ -284,6 +284,16 @@ def loadToolsConfig():
                     print("Invalid json file : "+str(fil))
     return default_tools_infos
 
+def saveToolsConfig(dic):
+    """
+    Save tools config file in the config/tools.d/ in tools.json 
+    Args:
+        dic: a dictionnary to write values
+    """
+    tool_config_folder = os.path.join(os.path.dirname(os.path.realpath(__file__)), "../../config/tools.d/")
+    default_tools_config = os.path.join(tool_config_folder, "tools.json")
+    with open(default_tools_config) as f:
+        f.write(json.dumps(dic))
 
 def loadClientConfig():
     """Return data converted from json inside config/client.cfg

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -43,7 +43,7 @@ RUN git clone --depth 1 https://github.com/drwetter/testssl.sh.git /home/testssl
 
 RUN python3 -m pip install --upgrade setuptools
 # Pollenisator
-RUN git clone https://github.com/fbarre96/Pollenisator-1.git /home/Pollenisator && \
+RUN git clone https://github.com/AlgoSecure/Pollenisator.git /home/Pollenisator && \
 	python3 -m pip install -r /home/Pollenisator/requirements.txt
 # Dirsearch as dirsearch.py
 RUN git clone https://github.com/maurosoria/dirsearch.git /home/dirsearch/ && \

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -43,7 +43,7 @@ RUN git clone --depth 1 https://github.com/drwetter/testssl.sh.git /home/testssl
 
 RUN python3 -m pip install --upgrade setuptools
 # Pollenisator
-RUN git clone https://github.com/AlgoSecure/Pollenisator.git /home/Pollenisator && \
+RUN git clone https://github.com/fbarre96/Pollenisator-1.git /home/Pollenisator && \
 	python3 -m pip install -r /home/Pollenisator/requirements.txt
 # Dirsearch as dirsearch.py
 RUN git clone https://github.com/maurosoria/dirsearch.git /home/dirsearch/ && \


### PR DESCRIPTION
 Ease adding command process : Issue #3 

- Changed scan worker treeview to show lacking commands specifically for each worker 
- Added double click on worker treeview nodes 
--> Open dialog to choose a plugin and enter the remote binary path.
--> Send those to worker for it to register the command
--> Re-fetch commands from worker

